### PR TITLE
Feat(확장) : "추가 styled-components 확장"

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,42 +1,34 @@
 import styled from "styled-components";
 
-//style.(사용하고자 하는 태그이름)에 백틱(`)을 이용해 css를 적용할 수 있다.
 const Father = styled.div`
   display: flex;
 `
 
-const BoxOne = styled.div`
-  background-color: teal;
+//속성을 동적으로 받아오고 싶을 때에는 해당 컴포넌트안에 속성명을 짓고
+//styled를 설정해줄 때 ${(props) => props.속성명}을 통해 해당 값을 가져올 수 있다.
+const Box = styled.div`
+  background-color: ${(props) => props.bgColor};
   width: 100px;
   height: 100px;
 `
 
-const BoxTwo = styled.div`
-  background-color: tomato;
+//box가 가진 속성에 border-radius를 추가하고 싶을 때 복사, 
+//붙여넣기가 아닌 styled(가져오고 싶은 컴포넌트 이름)을 통해 모든 css를 받아올 수 있다.
+
+// const Circle = styled.div`
+const Circle = styled(Box)`
+  background-color: ${(props) => props.bgColor};
   width: 100px;
   height: 100px;
-`
-
-const Text = styled.span`
-  color: white;
+  border-radius: 50px;
 `
 
 function App() {
   return (
-    //styled component를 사용하면 div의 늪에서 자유로워질 수 있다.
-    //요소검사에서 class명은 styled-component에서 임의로 정해져 적용된다.
     <Father>
-      <BoxOne>
-        <Text>Hello</Text>
-      </BoxOne>
-      <BoxTwo />
+      <Box bgColor="teal" />
+      <Circle bgColor="tomato"/>
     </Father>
-    
-    //가장 직관적이나 괄호를 각각 열어주어야하고 javascript 코드 방식으로 스타일을 지정해주어야 하는 단점이 있다.
-    // <div style={{display: "flex"}}>
-    //   <div style={{backgroundColor:"teal", width: 100, height: 100}}></div>
-    //   <div style={{backgroundColor:"tomato", width: 100, height: 100}}></div>
-    // </div>
   );
 }
 


### PR DESCRIPTION
styled-components를 쓸때 중복 코드를 피하는 방법과 확장하여 사용하는 방법

해당 컴포넌트 안에 동적으로 주고 싶은 속성명과 값을 넣어주고, styled를 선언하는 부분에서 ${(props) => props.속성명}을 통해 동적으로 값을 넣어줄 수 있다.

기존의 css를 확장하여 사용하고 싶은 경우, styled(해당 컴포넌트명)``을 통해 해당 컴포넌트의 css를 가져오고 추가로 입력하여 중복을 피할 수 있다.